### PR TITLE
Update Rails development example to 4.1 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ run MyApp
 In `config/environments/development.rb`
 
 ```ruby
-MyApp::Application.configure do
+Rails.application.configure do
   config.rack_dev_mark.enable = true
 end
 ```


### PR DESCRIPTION
The default syntax for `application.configure` changed from Rails 4.0 to Rails 4.1: http://railsdiff.org/diff/v4.0.8/v4.1.4/
