### PR TITLE
CI test against Ruby 2.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1
 
 env:
   -


### PR DESCRIPTION
Ruby switched to semantic versioning as of 2.1, so the third version level is now just the patch level. Using `2.1` is equivalent to the `1.9.3` and `2.0.0` version specifications: it will point to the latest patch level (that rvm knows about).
