### PR TITLE
Style tag in head

### DIFF
--- a/lib/rack/dev-mark/theme/github_fork_ribbon.rb
+++ b/lib/rack/dev-mark/theme/github_fork_ribbon.rb
@@ -27,9 +27,9 @@ module Rack
           div_tag_str = <<-EOS
 <div class="github-fork-ribbon-wrapper #{position}#{fixed}" onClick="this.style.display='none'" title="#{title}"><div class="github-fork-ribbon #{color}"><span class="github-fork-ribbon-text">#{env}</span></div></div>
           EOS
-          html
-            .sub('</head>', "#{style_tag_str.strip}</head>")
-            .sub %r{(<body[^>]*>)}i, "\\1#{div_tag_str.strip}"
+          html.
+            sub("</head>", "#{style_tag_str.strip}</head>").
+            sub /(<body[^>]*>)/i, "\\1#{div_tag_str.strip}"
         end
       end
     end

--- a/lib/rack/dev-mark/theme/github_fork_ribbon.rb
+++ b/lib/rack/dev-mark/theme/github_fork_ribbon.rb
@@ -29,7 +29,7 @@ module Rack
           EOS
           html.
             sub("</head>", "#{style_tag_str.strip}</head>").
-            sub /(<body[^>]*>)/i, "\\1#{div_tag_str.strip}"
+            sub(/(<body[^>]*>)/, "\\1#{div_tag_str.strip}")
         end
       end
     end

--- a/lib/rack/dev-mark/theme/github_fork_ribbon.rb
+++ b/lib/rack/dev-mark/theme/github_fork_ribbon.rb
@@ -17,15 +17,19 @@ module Rack
           title << timestamp if timestamp.to_s != ''
           title = title.join("&#10;")
 
-          s = <<-EOS
+          style_tag_str = <<-EOS
 #{stylesheet_link_tag "github-fork-ribbon-css/gh-fork-ribbon.css"}
 <!--[if lt IE 9]>
 #{stylesheet_link_tag "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}
 <![endif]-->
-<div class="github-fork-ribbon-wrapper #{position}#{fixed}" onClick="this.style.display='none'" title="#{title}"><div class="github-fork-ribbon #{color}"><span class="github-fork-ribbon-text">#{env}</span></div></div>
           EOS
 
-          html.sub %r{(<body[^>]*>)}i, "\\1#{s.strip}"
+          div_tag_str = <<-EOS
+<div class="github-fork-ribbon-wrapper #{position}#{fixed}" onClick="this.style.display='none'" title="#{title}"><div class="github-fork-ribbon #{color}"><span class="github-fork-ribbon-text">#{env}</span></div></div>
+          EOS
+          html
+            .sub('</head>', "#{style_tag_str.strip}</head>")
+            .sub %r{(<body[^>]*>)}i, "\\1#{div_tag_str.strip}"
         end
       end
     end

--- a/lib/rack/dev-mark/theme/github_fork_ribbon.rb
+++ b/lib/rack/dev-mark/theme/github_fork_ribbon.rb
@@ -18,9 +18,9 @@ module Rack
           title = title.join("&#10;")
 
           style_tag_str = <<-EOS
-#{stylesheet_link_tag "github-fork-ribbon-css/gh-fork-ribbon.css"}
+#{stylesheet_link_tag 'github-fork-ribbon-css/gh-fork-ribbon.css'}
 <!--[if lt IE 9]>
-#{stylesheet_link_tag "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}
+#{stylesheet_link_tag 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}
 <![endif]-->
           EOS
 

--- a/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
+++ b/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
@@ -19,7 +19,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
     it_behaves_like "theme" do
       let :out do
         s = <<-EOS
-<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.css'}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper right" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
@@ -34,7 +34,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
     it_behaves_like "theme" do
       let :out do
         s = <<-EOS
-<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.css'}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon orange"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
@@ -49,7 +49,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
     it_behaves_like "theme" do
       let :out do
         s = <<-EOS
-<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.css'}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper left fixed" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>

--- a/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
+++ b/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
@@ -5,11 +5,10 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
   it_behaves_like "theme" do
     let :out do
       s = <<-EOS
-<html><head>head<title>title</title></head><body><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
-<![endif]-->
-<div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
+<![endif]--></head><body><div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
       EOS
       s.strip
     end
@@ -20,11 +19,10 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
     it_behaves_like "theme" do
       let :out do
         s = <<-EOS
-<html><head>head<title>title</title></head><body><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
-<![endif]-->
-<div class="github-fork-ribbon-wrapper right" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
+<![endif]--></head><body><div class="github-fork-ribbon-wrapper right" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
         EOS
         s.strip
       end
@@ -36,11 +34,10 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
     it_behaves_like "theme" do
       let :out do
         s = <<-EOS
-<html><head>head<title>title</title></head><body><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
-<![endif]-->
-<div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon orange"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
+<![endif]--></head><body><div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon orange"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
         EOS
         s.strip
       end
@@ -52,11 +49,10 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
     it_behaves_like "theme" do
       let :out do
         s = <<-EOS
-<html><head>head<title>title</title></head><body><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
-<![endif]-->
-<div class="github-fork-ribbon-wrapper left fixed" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
+<![endif]--></head><body><div class="github-fork-ribbon-wrapper left fixed" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
         EOS
         s.strip
       end

--- a/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
+++ b/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
@@ -5,7 +5,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
   it_behaves_like "theme" do
     let :out do
       s = <<-EOS
-<html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
+<html><head>head<title>title</title><style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.css'}</style>
 <!--[if lt IE 9]>
 <style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>

--- a/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
+++ b/spec/rack/dev-mark/theme/github_fork_ribbon_spec.rb
@@ -7,7 +7,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
       s = <<-EOS
 <html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
-<style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
+<style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
       EOS
       s.strip
@@ -21,7 +21,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
         s = <<-EOS
 <html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
-<style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
+<style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper right" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
         EOS
         s.strip
@@ -36,7 +36,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
         s = <<-EOS
 <html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
-<style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
+<style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper left" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon orange"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
         EOS
         s.strip
@@ -51,7 +51,7 @@ describe Rack::DevMark::Theme::GithubForkRibbon do
         s = <<-EOS
 <html><head>head<title>title</title><style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.css"}</style>
 <!--[if lt IE 9]>
-<style>#{read_stylesheet "github-fork-ribbon-css/gh-fork-ribbon.ie.css"}</style>
+<style>#{read_stylesheet 'github-fork-ribbon-css/gh-fork-ribbon.ie.css'}</style>
 <![endif]--></head><body><div class="github-fork-ribbon-wrapper left fixed" onClick="this.style.display='none'" title="rev&#10;time"><div class="github-fork-ribbon red"><span class="github-fork-ribbon-text">env</span></div></div>body</body></html>
         EOS
         s.strip


### PR DESCRIPTION
Github-fork-ribbon theme inserts style tag into the beginning of body, but style tag should be in head.