### PR TITLE
Stop using Rack::Utils.bytesize

### DIFF
--- a/lib/rack/dev-mark/middleware.rb
+++ b/lib/rack/dev-mark/middleware.rb
@@ -33,7 +33,7 @@ module Rack
             end
           end
           response.close if response.respond_to?(:close)
-          headers['Content-Length'] &&= bytesize(new_body).to_s
+          headers['Content-Length'] &&= new_body.bytesize.to_s
           response = [new_body]
         end
 


### PR DESCRIPTION
Rack::DevMark::Middleware#call raise error because rack 2.0 removes Rack::Utils.bytesize.

https://github.com/rack/rack/commit/7b5820f8de7f9dffeb03d86588bba13fb0e91df1

Ruby 1.9+ supports String#bytesize, so just use it to fix.