### PR TITLE
Use before_action instead of before_filter

### DIFF
--- a/lib/rack/dev-mark/action_controller_helpers.rb
+++ b/lib/rack/dev-mark/action_controller_helpers.rb
@@ -3,7 +3,7 @@ module Rack
     module ActionControllerHelpers
       module ClassMethods
         def skip_rack_dev_mark(options = {})
-          before_filter options do
+          before_action options do
             disable_rack_dev_mark
           end
         end


### PR DESCRIPTION
Fix deprecation warning.

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.
```
