### PR TITLE
Update supported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
-  - 2.4
+  - 2.4.0
 
 install:
   - "gem install bundler"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
 
 install:
   - "gem install bundler"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
-  - 2.4.0
 
 install:
   - "gem install bundler"

--- a/rack-dev-mark.gemspec
+++ b/rack-dev-mark.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ['>= 2.1', '< 2.5']
 
-  gem.add_dependency "rack", ">= 1.1"
+  gem.add_dependency "rack", ['>= 1.1', '< 2.0']
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 3.0"

--- a/rack-dev-mark.gemspec
+++ b/rack-dev-mark.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = ['>= 2.1', '< 2.5']
 
   gem.add_dependency "rack", ">= 1.1"
 


### PR DESCRIPTION
I'm dropping Ruby 2.0 support since it has been EOS.
https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/

I also added Ruby 2.3 and 2.4 in travis test, and updated the required Ruby version of the gem spec.