### PR TITLE
Fork specs correctly

### DIFF
--- a/spec/support/fork_helper.rb
+++ b/spec/support/fork_helper.rb
@@ -11,6 +11,7 @@ shared_context 'forked spec' do
     Process.waitpid2 pid
     res = Marshal.load(read)
     example.example.send :set_exception, res if res && res.to_s != ''
+    example.instance_variable_set('@executed', true)
     read.close
   end
 end


### PR DESCRIPTION
It has reported the pending result since the examples have run in forked processes.
<img width="657" alt="screen shot 2017-01-06 at 5 48 40 pm" src="https://cloud.githubusercontent.com/assets/1162120/21712493/7be573cc-d438-11e6-9e9a-dfabc2dedb6b.png">

They should be marked as `executed`.