### PR TITLE
Allow failures instead of exclusion in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   - I18N_VERSION=0.6.0
 
 matrix:
-  exclude:
+  allow_failures:
     - rvm: 2.4.0
       env: RAILS_VERSION=3.2.0
     - rvm: 2.4.0


### PR DESCRIPTION
Allow failures on specific matrix of ruby and gems in travis so we can check the failures just in case.