### PR TITLE
Drop Ruby 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.1
   - 2.2
   - 2.3
   - 2.4.0
@@ -36,14 +35,6 @@ matrix:
       env: RAILS_VERSION=4.1.0
     - rvm: 2.4.0
       env: RAILS_VERSION=4.2.0
-    - rvm: 2.1
-      env: RACK_VERSION=2.0.0
-    - rvm: 2.1
-      env: RAILS_VERSION=5.0.0
-    - rvm: 2.1
-      env:
-    - rvm: 2.1
-      env: I18N_VERSION=0.6.0
 
 script: "bundle exec rake spec"
 

--- a/rack-dev-mark.gemspec
+++ b/rack-dev-mark.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.required_ruby_version = ['>= 2.1', '< 2.5']
+  gem.required_ruby_version = ['>= 2.2', '< 2.5']
 
   gem.add_dependency "rack", ['>= 1.1', '< 2.1']
 


### PR DESCRIPTION
Ruby 2.1 has been deprecated.

https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/