### PR TITLE
Drop Ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/rack-dev-mark.gemspec
+++ b/rack-dev-mark.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.required_ruby_version = ['>= 2.2']
+  gem.required_ruby_version = ['>= 2.3']
 
   gem.add_dependency "rack", ['>= 1.1', '< 2.1']
 


### PR DESCRIPTION
I'm dropping Ruby 2.2 support because it's been dropped already.
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/