### PR TITLE
relaxed rack version

### DIFF
--- a/rack-dev-mark.gemspec
+++ b/rack-dev-mark.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ['>= 2.3']
 
-  gem.add_dependency "rack", ['>= 1.1', '< 2.1']
+  gem.add_dependency "rack", ['>= 1.1', '< 2.2']
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 3.0"


### PR DESCRIPTION
Version 2.1.x of rack gem has been released.

But depends on a version smaller than 2.1, can not upgrading to the 2.1.x series of rack.