### PR TITLE
Loosen Rack dependency to allow Rack 3.x usage

### DIFF
--- a/rack-dev-mark.gemspec
+++ b/rack-dev-mark.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ['>= 2.3']
 
-  gem.add_dependency "rack", ['>= 1.1', '< 2.3']
+  gem.add_dependency "rack", ['>= 1.1', '< 4.0']
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 3.0"


### PR DESCRIPTION
This loosens the dependency requirement to allow for Rack 3.x. We implemented this at my company because Rack 3.0 was required to meet a security compliance.