### PR TITLE
Use Rack::Headers instead of Rack::Utils::HeaderHash

### DIFF
--- a/lib/rack/dev-mark/middleware.rb
+++ b/lib/rack/dev-mark/middleware.rb
@@ -18,7 +18,7 @@ module Rack
 
         status, headers, response = @app.call(env)
 
-        headers = HeaderHash.new(headers)
+        headers = Rack::Headers.new(headers)
 
         headers['X-Rack-Dev-Mark-Env'] = CGI.escape Rack::DevMark.env
 


### PR DESCRIPTION
This PR is for warning text: `Rack::Utils::HeaderHash is deprecated and will be removed in Rack 3.1`
Issue: #67 