### PR TITLE
Use String.new instead of ''

### DIFF
--- a/lib/rack/dev-mark/middleware.rb
+++ b/lib/rack/dev-mark/middleware.rb
@@ -24,7 +24,7 @@ module Rack
 
         redirect = 300 <= status.to_i && status.to_i < 400
         if !redirect && !Rack::DevMark.tmp_disabled && read_headers['Content-Type'].to_s =~ %r{\btext/html\b}i
-          new_body = String.new('')
+          new_body = +''
           response.each do |b|
             begin
               new_body << insert_dev_marks(b)

--- a/lib/rack/dev-mark/middleware.rb
+++ b/lib/rack/dev-mark/middleware.rb
@@ -24,7 +24,7 @@ module Rack
 
         redirect = 300 <= status.to_i && status.to_i < 400
         if !redirect && !Rack::DevMark.tmp_disabled && read_headers['Content-Type'].to_s =~ %r{\btext/html\b}i
-          new_body = ''
+          new_body = String.new('')
           response.each do |b|
             begin
               new_body << insert_dev_marks(b)


### PR DESCRIPTION
In Ruby 3.5+, literal strings will be frozen. This change allows for a mutable string.