### PR TITLE
Make response headers compliant with Rack 3 specification

### DIFF
--- a/lib/rack/dev-mark/middleware.rb
+++ b/lib/rack/dev-mark/middleware.rb
@@ -20,7 +20,7 @@ module Rack
 
         read_headers = defined?(Rack::Headers) ? Rack::Headers.new(headers) : HeaderHash.new(headers)
 
-        headers['X-Rack-Dev-Mark-Env'] = CGI.escape Rack::DevMark.env
+        headers['x-rack-dev-mark-env'] = CGI.escape Rack::DevMark.env
 
         redirect = 300 <= status.to_i && status.to_i < 400
         if !redirect && !Rack::DevMark.tmp_disabled && read_headers['Content-Type'].to_s =~ %r{\btext/html\b}i
@@ -33,7 +33,7 @@ module Rack
             end
           end
           response.close if response.respond_to?(:close)
-          headers['Content-Length'] = new_body.bytesize.to_s if read_headers['Content-Length']
+          headers['content-length'] = new_body.bytesize.to_s if read_headers['Content-Length']
           response = [new_body]
         end
 

--- a/spec/rack/dev-mark/middleware_spec.rb
+++ b/spec/rack/dev-mark/middleware_spec.rb
@@ -25,14 +25,14 @@ describe Rack::DevMark::Middleware do
     context "ASCII env string" do
       it "adds http headers" do
         _, headers, _ = subject.call({})
-        expect(headers).to include('X-Rack-Dev-Mark-Env' => 'test')
+        expect(headers).to include('x-rack-dev-mark-env' => 'test')
       end
     end
     context "Non ASCII string" do
       let(:env) { 'テスト' }
       it "adds http headers" do
         _, headers, _ = subject.call({})
-        expect(headers).to include('X-Rack-Dev-Mark-Env' => '%E3%83%86%E3%82%B9%E3%83%88')
+        expect(headers).to include('x-rack-dev-mark-env' => '%E3%83%86%E3%82%B9%E3%83%88')
       end
     end
   end


### PR DESCRIPTION

In Rack 3.x, response header names are no longer allowed to contain uppercase characters.
As a result, environments that enable `Rack::Lint` raise an error when such headers are present.

Relevant implementation:
https://github.com/rack/rack/blob/v3.2.4/lib/rack/lint.rb#L728-L729

The following `config.ru` reproduces the issue when using `rack-dev-mark`:

```ruby
require "rack"
require "rack/dev-mark"

use Rack::DevMark::Middleware

run ->(env) do
  status = 200
  headers = { "content-type" => "text/html" }
  body = [<<~HTML]
    <html>
      <head><title>Hello World</title></head>
      <body><h1>It's Works!</h1></body>
    </html>
  HTML

  [status, headers, body]
end
```

Running `rackup` and accessing http://127.0.0.1:9292 results in the following error:
```
Rack::Lint::LintError: uppercase character in header name: X-Rack-Dev-Mark-Env (Rack::Lint::LintError)
```

This pull request updates the response header names to conform to the Rack 3 specification,
thereby avoiding this error.
